### PR TITLE
feat(db): agregar estado publish/draft y auto-draft al editar productos

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.1.7",
     "postcss": "^8",
-    "supabase": "^2.53.6",
+    "supabase": "2.67.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^8
         version: 8.5.3
       supabase:
-        specifier: ^2.53.6
-        version: 2.53.6
+        specifier: 2.67.2
+        version: 2.67.2
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
@@ -886,9 +886,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  bin-links@5.0.0:
-    resolution: {integrity: sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  bin-links@6.0.0:
+    resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -946,9 +946,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
-  cmd-shim@7.0.0:
-    resolution: {integrity: sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  cmd-shim@8.0.0:
+    resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1748,9 +1748,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  npm-normalize-package-bin@4.0.0:
-    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  npm-normalize-package-bin@5.0.0:
+    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1898,9 +1898,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  proc-log@5.0.0:
-    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -1932,9 +1932,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
-  read-cmd-shim@5.0.0:
-    resolution: {integrity: sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  read-cmd-shim@6.0.0:
+    resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -2123,8 +2123,8 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
-  supabase@2.53.6:
-    resolution: {integrity: sha512-tvMSykcxBaFm2SAKx93h6h4HjfJnWZV0kxO2P3i491Mtnu/95knLjSxr5gu7/tAJtPFuEMG/0m1kNGOHPSE6YA==}
+  supabase@2.67.2:
+    resolution: {integrity: sha512-JDOLNGfH9SPHApqRCH4XgGseSIFVZ9F/43eWfCf1dxpUm9YPND52G7QemWrJieqBtmw2MoMzGYLQHHQtxiwHXw==}
     engines: {npm: '>=8'}
     hasBin: true
 
@@ -2157,8 +2157,8 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.1:
-    resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
+  tar@7.5.2:
+    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
 
   thenify-all@1.6.0:
@@ -2319,9 +2319,9 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  write-file-atomic@6.0.0:
-    resolution: {integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  write-file-atomic@7.0.0:
+    resolution: {integrity: sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ws@8.18.2:
     resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
@@ -3035,13 +3035,13 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  bin-links@5.0.0:
+  bin-links@6.0.0:
     dependencies:
-      cmd-shim: 7.0.0
-      npm-normalize-package-bin: 4.0.0
-      proc-log: 5.0.0
-      read-cmd-shim: 5.0.0
-      write-file-atomic: 6.0.0
+      cmd-shim: 8.0.0
+      npm-normalize-package-bin: 5.0.0
+      proc-log: 6.1.0
+      read-cmd-shim: 6.0.0
+      write-file-atomic: 7.0.0
 
   binary-extensions@2.3.0: {}
 
@@ -3106,7 +3106,7 @@ snapshots:
 
   client-only@0.0.1: {}
 
-  cmd-shim@7.0.0: {}
+  cmd-shim@8.0.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -4052,7 +4052,7 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  npm-normalize-package-bin@4.0.0: {}
+  npm-normalize-package-bin@5.0.0: {}
 
   object-assign@4.1.1: {}
 
@@ -4194,7 +4194,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  proc-log@5.0.0: {}
+  proc-log@6.1.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -4223,7 +4223,7 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
-  read-cmd-shim@5.0.0: {}
+  read-cmd-shim@6.0.0: {}
 
   readdirp@3.6.0:
     dependencies:
@@ -4507,12 +4507,12 @@ snapshots:
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
 
-  supabase@2.53.6:
+  supabase@2.67.2:
     dependencies:
-      bin-links: 5.0.0
+      bin-links: 6.0.0
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
-      tar: 7.5.1
+      tar: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4560,7 +4560,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  tar@7.5.1:
+  tar@7.5.2:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -4743,7 +4743,7 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  write-file-atomic@6.0.0:
+  write-file-atomic@7.0.0:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0

--- a/supabase/migrations/20251218031035_remote_schema.sql
+++ b/supabase/migrations/20251218031035_remote_schema.sql
@@ -1,0 +1,1476 @@
+
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+
+
+
+ALTER SCHEMA "public" OWNER TO "postgres";
+
+
+CREATE EXTENSION IF NOT EXISTS "pg_graphql" WITH SCHEMA "graphql";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pg_stat_statements" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "supabase_vault" WITH SCHEMA "vault";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE TYPE "public"."rol_membresia" AS ENUM (
+    'owner',
+    'admin',
+    'empleado',
+    'invitado'
+);
+
+
+ALTER TYPE "public"."rol_membresia" OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."can_manage_producto"("p_producto" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM producto pr
+    JOIN empresa e ON e.id = pr.empresa_id
+    WHERE pr.id = p_producto AND e.owner_auth = auth.uid()
+  );
+$$;
+
+
+ALTER FUNCTION "public"."can_manage_producto"("p_producto" "uuid") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."ensure_personal_org"() RETURNS TABLE("empresa_id" "uuid", "rol" "public"."rol_membresia")
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+declare
+  v_uid uuid := auth.uid();
+  v_empresa uuid;
+  v_rol_out rol_membresia;
+  v_slug text;
+  v_uid_exists boolean;
+  v_has_owner_auth boolean;
+begin
+  if v_uid is null then
+    raise exception 'Debe estar autenticado';
+  end if;
+
+  -- validar que el uid exista en auth.users
+  select exists(select 1 from auth.users where id = v_uid) into v_uid_exists;
+  if not v_uid_exists then
+    raise exception 'El usuario % no existe en auth.users', v_uid;
+  end if;
+
+  -- ¿ya tiene membresía?
+  select m.empresa_id, m.rol
+  into v_empresa, v_rol_out
+  from public.membresia m
+  where m.usuario_id = v_uid
+  limit 1;
+
+  if v_empresa is not null then
+    empresa_id := v_empresa; rol := v_rol_out; return next; return;
+  end if;
+
+  -- verificar si la tabla empresa tiene columna owner_auth
+  select exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='empresa' and column_name='owner_auth'
+  ) into v_has_owner_auth;
+
+  v_slug := 'personal-' || substr(replace(v_uid::text, '-', ''), 1, 8);
+
+  if v_has_owner_auth then
+    insert into public.empresa (nombre, slug, created_by, owner_auth)
+    values ('Mi empresa', v_slug, v_uid, v_uid)
+    returning id into v_empresa;
+  else
+    insert into public.empresa (nombre, slug, created_by)
+    values ('Mi empresa', v_slug, v_uid)
+    returning id into v_empresa;
+  end if;
+
+  -- crear membresía owner (sin RETURNING para evitar ambigüedad)
+  insert into public.membresia (empresa_id, usuario_id, rol)
+  values (v_empresa, v_uid, 'owner');
+
+  v_rol_out := 'owner';
+
+  empresa_id := v_empresa;
+  rol := v_rol_out;
+  return next;
+end
+$$;
+
+
+ALTER FUNCTION "public"."ensure_personal_org"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."handle_new_auth_user"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+declare
+  v_nombre text;
+begin
+  v_nombre := coalesce(
+    new.raw_user_meta_data->>'name',
+    new.raw_user_meta_data->>'full_name',
+    split_part(new.email, '@', 1),
+    'Usuario'
+  );
+
+  begin
+    insert into public.usuario (id, supabase_uid, correo, nombre, rol, fecha_registro)
+    values (new.id, new.id, new.email, v_nombre, 'cliente', now());
+  exception
+    when unique_violation then
+      -- Si la violación es por el correo (usuario ya existía con ese email),
+      -- lo adoptamos asignando el nuevo id/supabase_uid y refrescamos nombre.
+      update public.usuario
+         set id = new.id,
+             supabase_uid = new.id,
+             nombre = coalesce(public.usuario.nombre, v_nombre),
+             rol = coalesce(public.usuario.rol, 'cliente')
+       where correo = new.email;
+  end;
+
+  return new;
+end
+$$;
+
+
+ALTER FUNCTION "public"."handle_new_auth_user"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."handle_new_user"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+begin
+  insert into public.usuario (id, correo, nombre, rol, empresa_id, supabase_uid)
+  values (
+    new.id,                                   -- id del auth.user
+    new.email,                                -- correo
+    coalesce(new.raw_user_meta_data->>'name', ''),
+    'cliente',
+    null,
+    new.id                                    -- mantenemos también supabase_uid por consistencia
+  )
+  on conflict (id) do nothing;
+
+  -- log (si creaste event_log)
+  insert into public.event_log (event_type, user_id, email, details)
+  values (
+    'auth_user_created',
+    new.id,
+    new.email,
+    jsonb_build_object('raw_metadata', new.raw_user_meta_data, 'created_auth_at', new.created_at, 'inserted_at', now())
+  );
+
+  return new;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."handle_new_user"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."is_empresa_owner"("p_empresa" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE
+    AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM empresa e
+    WHERE e.id = p_empresa AND e.owner_auth = auth.uid()
+  );
+$$;
+
+
+ALTER FUNCTION "public"."is_empresa_owner"("p_empresa" "uuid") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."owns_carrito"("p_carrito" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE
+    AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM carrito c
+    WHERE c.id = p_carrito AND c.usuario_id = auth.uid()
+  );
+$$;
+
+
+ALTER FUNCTION "public"."owns_carrito"("p_carrito" "uuid") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."owns_pedido"("p_pedido" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE
+    AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM pedido p
+    WHERE p.id = p_pedido AND p.usuario_id = auth.uid()
+  );
+$$;
+
+
+ALTER FUNCTION "public"."owns_pedido"("p_pedido" "uuid") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."set_supabase_uid_from_jwt"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $$
+DECLARE sub text;
+BEGIN
+  sub := current_setting('request.jwt.claim.sub', true);
+  IF NEW.supabase_uid IS NULL AND sub IS NOT NULL THEN
+    NEW.supabase_uid := sub::uuid;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."set_supabase_uid_from_jwt"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."user_is_member_of"("p_empresa" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  select exists(
+    select 1
+    from public.membresia m
+    where m.empresa_id = p_empresa
+      and m.usuario_id = auth.uid()
+  );
+$$;
+
+
+ALTER FUNCTION "public"."user_is_member_of"("p_empresa" "uuid") OWNER TO "postgres";
+
+SET default_tablespace = '';
+
+SET default_table_access_method = "heap";
+
+
+CREATE TABLE IF NOT EXISTS "public"."carrito" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "usuario_id" "uuid",
+    "creado_en" timestamp without time zone DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."carrito" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."carrito_producto" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "carrito_id" "uuid",
+    "producto_id" "uuid",
+    "cantidad" integer NOT NULL,
+    CONSTRAINT "chk_cp_cantidad_pos" CHECK (("cantidad" > 0))
+);
+
+
+ALTER TABLE "public"."carrito_producto" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."categoria" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "nombre" character varying(255) NOT NULL,
+    "descripcion" "text",
+    "empresa_id" "uuid",
+    "slug" "text",
+    "orden" integer DEFAULT 0,
+    "parent_id" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "updated_at" timestamp with time zone DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."categoria" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."comprobante_pago" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "pedido_id" "uuid" NOT NULL,
+    "monto" numeric(10,2) NOT NULL,
+    "fecha_pago" timestamp without time zone DEFAULT "now"(),
+    "metodo_pago" character varying(50),
+    "estado_pago" character varying(50) DEFAULT 'Pendiente'::character varying,
+    CONSTRAINT "chk_estado_pago" CHECK ((("estado_pago")::"text" = ANY ((ARRAY['Pendiente'::character varying, 'Aprobado'::character varying, 'Rechazado'::character varying, 'Reembolsado'::character varying])::"text"[])))
+);
+
+
+ALTER TABLE "public"."comprobante_pago" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."direccion_usuario" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "usuario_id" "uuid" NOT NULL,
+    "direccion" character varying(255) NOT NULL,
+    "ciudad" character varying(100) NOT NULL,
+    "pais" character varying(100) NOT NULL,
+    "codigo_postal" character varying(20),
+    "tipo_direccion" character varying(50),
+    "fecha_creacion" timestamp without time zone DEFAULT "now"(),
+    CONSTRAINT "chk_tipo_direccion" CHECK ((("tipo_direccion")::"text" = ANY ((ARRAY['hogar'::character varying, 'trabajo'::character varying, 'otro'::character varying])::"text"[])))
+);
+
+
+ALTER TABLE "public"."direccion_usuario" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."empresa" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "nombre" character varying(255) NOT NULL,
+    "descripcion" "text",
+    "fecha_creacion" timestamp without time zone DEFAULT "now"(),
+    "owner_auth" "uuid",
+    "slug" "text",
+    "created_by" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."empresa" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."envio" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "pedido_id" "uuid" NOT NULL,
+    "direccion_envio_id" "uuid",
+    "fecha_envio" timestamp without time zone DEFAULT "now"(),
+    "estado_envio" character varying(50) DEFAULT 'En preparación'::character varying,
+    CONSTRAINT "chk_estado_envio" CHECK ((("estado_envio")::"text" = ANY ((ARRAY['En preparación'::character varying, 'En tránsito'::character varying, 'Entregado'::character varying, 'Cancelado'::character varying])::"text"[])))
+);
+
+
+ALTER TABLE "public"."envio" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."event_log" (
+    "id" bigint NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "event_type" "text" NOT NULL,
+    "user_id" "uuid",
+    "email" "text",
+    "details" "jsonb"
+);
+
+
+ALTER TABLE "public"."event_log" OWNER TO "postgres";
+
+
+ALTER TABLE "public"."event_log" ALTER COLUMN "id" ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME "public"."event_log_id_seq"
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+
+CREATE TABLE IF NOT EXISTS "public"."favorito" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "usuario_id" "uuid",
+    "producto_id" "uuid"
+);
+
+
+ALTER TABLE "public"."favorito" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."historial_stock" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "producto_id" "uuid",
+    "cantidad" integer NOT NULL,
+    "fecha" timestamp without time zone DEFAULT "now"(),
+    "motivo" "text",
+    CONSTRAINT "chk_hs_cantidad_nonzero" CHECK (("cantidad" <> 0))
+);
+
+
+ALTER TABLE "public"."historial_stock" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."imagen_producto" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "producto_id" "uuid",
+    "url_imagen" character varying(255) NOT NULL,
+    "descripcion" character varying(255),
+    "creado_en" timestamp without time zone DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."imagen_producto" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."log_actividad" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "usuario_id" "uuid",
+    "actividad" "text" NOT NULL,
+    "fecha" timestamp without time zone DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."log_actividad" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."membresia" (
+    "empresa_id" "uuid" NOT NULL,
+    "usuario_id" "uuid" NOT NULL,
+    "rol" "public"."rol_membresia" DEFAULT 'invitado'::"public"."rol_membresia" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."membresia" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."notificacion" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "usuario_id" "uuid",
+    "mensaje" "text" NOT NULL,
+    "fecha" timestamp without time zone DEFAULT "now"(),
+    "leido" boolean DEFAULT false
+);
+
+
+ALTER TABLE "public"."notificacion" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."pedido" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "usuario_id" "uuid",
+    "fecha_pedido" timestamp without time zone DEFAULT "now"(),
+    "direccion_envio_id" "uuid",
+    "estado" character varying(50) DEFAULT 'Pendiente'::character varying
+);
+
+
+ALTER TABLE "public"."pedido" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."producto" (
+    "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,
+    "nombre" character varying(255) NOT NULL,
+    "descripcion" "text",
+    "precio" numeric(10,2) NOT NULL,
+    "stock" integer NOT NULL,
+    "tipo" character varying(50),
+    "categoria_id" "uuid",
+    "empresa_id" "uuid",
+    "creado_en" timestamp without time zone DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."producto" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."usuario" (
+    "id" "uuid" NOT NULL,
+    "nombre" character varying(255) NOT NULL,
+    "correo" character varying(255) NOT NULL,
+    "rol" character varying(50) DEFAULT 'cliente'::character varying NOT NULL,
+    "empresa_id" "uuid",
+    "telefono" character varying(15),
+    "direccion" character varying(255),
+    "fecha_registro" timestamp without time zone DEFAULT "now"(),
+    "supabase_uid" "uuid" NOT NULL
+);
+
+
+ALTER TABLE "public"."usuario" OWNER TO "postgres";
+
+
+ALTER TABLE ONLY "public"."carrito"
+    ADD CONSTRAINT "carrito_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."carrito_producto"
+    ADD CONSTRAINT "carrito_producto_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."categoria"
+    ADD CONSTRAINT "categoria_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."comprobante_pago"
+    ADD CONSTRAINT "comprobante_pago_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."direccion_usuario"
+    ADD CONSTRAINT "direccion_usuario_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."empresa"
+    ADD CONSTRAINT "empresa_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."envio"
+    ADD CONSTRAINT "envio_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."event_log"
+    ADD CONSTRAINT "event_log_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."favorito"
+    ADD CONSTRAINT "favorito_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."historial_stock"
+    ADD CONSTRAINT "historial_stock_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."imagen_producto"
+    ADD CONSTRAINT "imagen_producto_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."log_actividad"
+    ADD CONSTRAINT "log_actividad_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."membresia"
+    ADD CONSTRAINT "membresia_pkey" PRIMARY KEY ("empresa_id", "usuario_id");
+
+
+
+ALTER TABLE ONLY "public"."notificacion"
+    ADD CONSTRAINT "notificacion_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."pedido"
+    ADD CONSTRAINT "pedido_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."producto"
+    ADD CONSTRAINT "producto_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."usuario"
+    ADD CONSTRAINT "usuario_correo_key" UNIQUE ("correo");
+
+
+
+ALTER TABLE ONLY "public"."usuario"
+    ADD CONSTRAINT "usuario_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."usuario"
+    ADD CONSTRAINT "usuario_supabase_uid_unique" UNIQUE ("supabase_uid");
+
+
+
+CREATE UNIQUE INDEX "empresa_slug_key" ON "public"."empresa" USING "btree" ("slug");
+
+
+
+CREATE INDEX "idx_cp_carrito" ON "public"."carrito_producto" USING "btree" ("carrito_id");
+
+
+
+CREATE INDEX "idx_cp_pedido" ON "public"."comprobante_pago" USING "btree" ("pedido_id");
+
+
+
+CREATE INDEX "idx_cp_producto" ON "public"."carrito_producto" USING "btree" ("producto_id");
+
+
+
+CREATE INDEX "idx_du_usuario" ON "public"."direccion_usuario" USING "btree" ("usuario_id");
+
+
+
+CREATE INDEX "idx_empresa_owner_auth" ON "public"."empresa" USING "btree" ("owner_auth");
+
+
+
+CREATE INDEX "idx_envio_estado" ON "public"."envio" USING "btree" ("estado_envio");
+
+
+
+CREATE INDEX "idx_envio_pedido" ON "public"."envio" USING "btree" ("pedido_id");
+
+
+
+CREATE INDEX "idx_event_log_created_at" ON "public"."event_log" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "idx_event_log_event_type" ON "public"."event_log" USING "btree" ("event_type");
+
+
+
+CREATE INDEX "idx_hs_producto" ON "public"."historial_stock" USING "btree" ("producto_id");
+
+
+
+CREATE INDEX "idx_ip_producto" ON "public"."imagen_producto" USING "btree" ("producto_id");
+
+
+
+CREATE INDEX "idx_membresia_empresa" ON "public"."membresia" USING "btree" ("empresa_id");
+
+
+
+CREATE INDEX "idx_membresia_usuario" ON "public"."membresia" USING "btree" ("usuario_id");
+
+
+
+CREATE INDEX "idx_pedido_usuario" ON "public"."pedido" USING "btree" ("usuario_id");
+
+
+
+CREATE INDEX "idx_producto_categoria" ON "public"."producto" USING "btree" ("categoria_id");
+
+
+
+CREATE INDEX "idx_producto_empresa" ON "public"."producto" USING "btree" ("empresa_id");
+
+
+
+CREATE UNIQUE INDEX "ux_cp_carrito_producto" ON "public"."carrito_producto" USING "btree" ("carrito_id", "producto_id");
+
+
+
+CREATE UNIQUE INDEX "ux_du_usuario_direccion" ON "public"."direccion_usuario" USING "btree" ("usuario_id", "direccion", "ciudad", "pais");
+
+
+
+CREATE OR REPLACE TRIGGER "usuario_set_uid" BEFORE INSERT ON "public"."usuario" FOR EACH ROW EXECUTE FUNCTION "public"."set_supabase_uid_from_jwt"();
+
+
+
+ALTER TABLE ONLY "public"."carrito_producto"
+    ADD CONSTRAINT "carrito_producto_carrito_id_fkey" FOREIGN KEY ("carrito_id") REFERENCES "public"."carrito"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."carrito_producto"
+    ADD CONSTRAINT "carrito_producto_producto_id_fkey" FOREIGN KEY ("producto_id") REFERENCES "public"."producto"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."categoria"
+    ADD CONSTRAINT "categoria_empresa_id_fkey" FOREIGN KEY ("empresa_id") REFERENCES "public"."empresa"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."categoria"
+    ADD CONSTRAINT "categoria_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "public"."categoria"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."comprobante_pago"
+    ADD CONSTRAINT "comprobante_pago_pedido_id_fkey" FOREIGN KEY ("pedido_id") REFERENCES "public"."pedido"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."empresa"
+    ADD CONSTRAINT "empresa_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;
+
+
+
+ALTER TABLE ONLY "public"."empresa"
+    ADD CONSTRAINT "empresa_owner_auth_fkey" FOREIGN KEY ("owner_auth") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;
+
+
+
+ALTER TABLE ONLY "public"."envio"
+    ADD CONSTRAINT "envio_direccion_envio_id_fkey" FOREIGN KEY ("direccion_envio_id") REFERENCES "public"."direccion_usuario"("id");
+
+
+
+ALTER TABLE ONLY "public"."envio"
+    ADD CONSTRAINT "envio_pedido_id_fkey" FOREIGN KEY ("pedido_id") REFERENCES "public"."pedido"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."favorito"
+    ADD CONSTRAINT "favorito_producto_id_fkey" FOREIGN KEY ("producto_id") REFERENCES "public"."producto"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."carrito"
+    ADD CONSTRAINT "fk_carrito_usuario" FOREIGN KEY ("usuario_id") REFERENCES "public"."usuario"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."carrito_producto"
+    ADD CONSTRAINT "fk_cp_carrito" FOREIGN KEY ("carrito_id") REFERENCES "public"."carrito"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."comprobante_pago"
+    ADD CONSTRAINT "fk_cp_pedido" FOREIGN KEY ("pedido_id") REFERENCES "public"."pedido"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."carrito_producto"
+    ADD CONSTRAINT "fk_cp_producto" FOREIGN KEY ("producto_id") REFERENCES "public"."producto"("id") ON DELETE RESTRICT;
+
+
+
+ALTER TABLE ONLY "public"."direccion_usuario"
+    ADD CONSTRAINT "fk_du_usuario" FOREIGN KEY ("usuario_id") REFERENCES "public"."usuario"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."envio"
+    ADD CONSTRAINT "fk_envio_direccion" FOREIGN KEY ("direccion_envio_id") REFERENCES "public"."direccion_usuario"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."envio"
+    ADD CONSTRAINT "fk_envio_pedido" FOREIGN KEY ("pedido_id") REFERENCES "public"."pedido"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."historial_stock"
+    ADD CONSTRAINT "fk_hs_producto" FOREIGN KEY ("producto_id") REFERENCES "public"."producto"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."imagen_producto"
+    ADD CONSTRAINT "fk_ip_producto" FOREIGN KEY ("producto_id") REFERENCES "public"."producto"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."log_actividad"
+    ADD CONSTRAINT "fk_log_usuario" FOREIGN KEY ("usuario_id") REFERENCES "public"."usuario"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."pedido"
+    ADD CONSTRAINT "fk_pedido_direccion" FOREIGN KEY ("direccion_envio_id") REFERENCES "public"."direccion_usuario"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."pedido"
+    ADD CONSTRAINT "fk_pedido_usuario" FOREIGN KEY ("usuario_id") REFERENCES "public"."usuario"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."producto"
+    ADD CONSTRAINT "fk_producto_categoria" FOREIGN KEY ("categoria_id") REFERENCES "public"."categoria"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."producto"
+    ADD CONSTRAINT "fk_producto_empresa" FOREIGN KEY ("empresa_id") REFERENCES "public"."empresa"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."usuario"
+    ADD CONSTRAINT "fk_usuario_empresa" FOREIGN KEY ("empresa_id") REFERENCES "public"."empresa"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."historial_stock"
+    ADD CONSTRAINT "historial_stock_producto_id_fkey" FOREIGN KEY ("producto_id") REFERENCES "public"."producto"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."imagen_producto"
+    ADD CONSTRAINT "imagen_producto_producto_id_fkey" FOREIGN KEY ("producto_id") REFERENCES "public"."producto"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."membresia"
+    ADD CONSTRAINT "membresia_empresa_id_fkey" FOREIGN KEY ("empresa_id") REFERENCES "public"."empresa"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."membresia"
+    ADD CONSTRAINT "membresia_usuario_id_fkey" FOREIGN KEY ("usuario_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."pedido"
+    ADD CONSTRAINT "pedido_direccion_envio_id_fkey" FOREIGN KEY ("direccion_envio_id") REFERENCES "public"."direccion_usuario"("id");
+
+
+
+ALTER TABLE ONLY "public"."producto"
+    ADD CONSTRAINT "producto_categoria_id_fkey" FOREIGN KEY ("categoria_id") REFERENCES "public"."categoria"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."producto"
+    ADD CONSTRAINT "producto_empresa_id_fkey" FOREIGN KEY ("empresa_id") REFERENCES "public"."empresa"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."usuario"
+    ADD CONSTRAINT "usuario_empresa_id_fkey" FOREIGN KEY ("empresa_id") REFERENCES "public"."empresa"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE "public"."carrito" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "carrito_del_own" ON "public"."carrito" FOR DELETE TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "carrito_ins_own" ON "public"."carrito" FOR INSERT TO "authenticated" WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+ALTER TABLE "public"."carrito_producto" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "carrito_sel_own" ON "public"."carrito" FOR SELECT TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "carrito_upd_own" ON "public"."carrito" FOR UPDATE TO "authenticated" USING (("usuario_id" = "auth"."uid"())) WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+ALTER TABLE "public"."categoria" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "categoria_all_true" ON "public"."categoria" USING (true) WITH CHECK (true);
+
+
+
+ALTER TABLE "public"."comprobante_pago" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "cp_del_own" ON "public"."carrito_producto" FOR DELETE TO "authenticated" USING ("public"."owns_carrito"("carrito_id"));
+
+
+
+CREATE POLICY "cp_del_own" ON "public"."comprobante_pago" FOR DELETE TO "authenticated" USING ("public"."owns_pedido"("pedido_id"));
+
+
+
+CREATE POLICY "cp_ins_own" ON "public"."carrito_producto" FOR INSERT TO "authenticated" WITH CHECK ("public"."owns_carrito"("carrito_id"));
+
+
+
+CREATE POLICY "cp_ins_own" ON "public"."comprobante_pago" FOR INSERT TO "authenticated" WITH CHECK ("public"."owns_pedido"("pedido_id"));
+
+
+
+CREATE POLICY "cp_sel_own" ON "public"."carrito_producto" FOR SELECT TO "authenticated" USING ("public"."owns_carrito"("carrito_id"));
+
+
+
+CREATE POLICY "cp_sel_own" ON "public"."comprobante_pago" FOR SELECT TO "authenticated" USING ("public"."owns_pedido"("pedido_id"));
+
+
+
+CREATE POLICY "cp_upd_own" ON "public"."carrito_producto" FOR UPDATE TO "authenticated" USING ("public"."owns_carrito"("carrito_id")) WITH CHECK ("public"."owns_carrito"("carrito_id"));
+
+
+
+CREATE POLICY "cp_upd_own" ON "public"."comprobante_pago" FOR UPDATE TO "authenticated" USING ("public"."owns_pedido"("pedido_id")) WITH CHECK ("public"."owns_pedido"("pedido_id"));
+
+
+
+ALTER TABLE "public"."direccion_usuario" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "du_del_own" ON "public"."direccion_usuario" FOR DELETE TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "du_ins_own" ON "public"."direccion_usuario" FOR INSERT TO "authenticated" WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "du_sel_own" ON "public"."direccion_usuario" FOR SELECT TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "du_upd_own" ON "public"."direccion_usuario" FOR UPDATE TO "authenticated" USING (("usuario_id" = "auth"."uid"())) WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+ALTER TABLE "public"."empresa" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "empresa_del_own" ON "public"."empresa" FOR DELETE TO "authenticated" USING (("owner_auth" = "auth"."uid"()));
+
+
+
+CREATE POLICY "empresa_delete_owners" ON "public"."empresa" FOR DELETE USING ((EXISTS ( SELECT 1
+   FROM "public"."membresia" "m"
+  WHERE (("m"."empresa_id" = "empresa"."id") AND ("m"."usuario_id" = "auth"."uid"()) AND ("m"."rol" = 'owner'::"public"."rol_membresia")))));
+
+
+
+CREATE POLICY "empresa_ins_own" ON "public"."empresa" FOR INSERT TO "authenticated" WITH CHECK (("owner_auth" = "auth"."uid"()));
+
+
+
+CREATE POLICY "empresa_insert_owner" ON "public"."empresa" FOR INSERT TO "authenticated" WITH CHECK (("created_by" = "auth"."uid"()));
+
+
+
+CREATE POLICY "empresa_sel_own" ON "public"."empresa" FOR SELECT TO "authenticated" USING (("owner_auth" = "auth"."uid"()));
+
+
+
+CREATE POLICY "empresa_select_members" ON "public"."empresa" FOR SELECT USING (("public"."user_is_member_of"("id") OR ("created_by" = "auth"."uid"())));
+
+
+
+CREATE POLICY "empresa_upd_own" ON "public"."empresa" FOR UPDATE TO "authenticated" USING (("owner_auth" = "auth"."uid"())) WITH CHECK (("owner_auth" = "auth"."uid"()));
+
+
+
+CREATE POLICY "empresa_update_admins" ON "public"."empresa" FOR UPDATE USING ("public"."user_is_member_of"("id")) WITH CHECK ("public"."user_is_member_of"("id"));
+
+
+
+ALTER TABLE "public"."envio" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "envio_del_own" ON "public"."envio" FOR DELETE TO "authenticated" USING ("public"."owns_pedido"("pedido_id"));
+
+
+
+CREATE POLICY "envio_ins_own" ON "public"."envio" FOR INSERT TO "authenticated" WITH CHECK ("public"."owns_pedido"("pedido_id"));
+
+
+
+CREATE POLICY "envio_sel_own" ON "public"."envio" FOR SELECT TO "authenticated" USING ("public"."owns_pedido"("pedido_id"));
+
+
+
+CREATE POLICY "envio_upd_own" ON "public"."envio" FOR UPDATE TO "authenticated" USING ("public"."owns_pedido"("pedido_id")) WITH CHECK ("public"."owns_pedido"("pedido_id"));
+
+
+
+ALTER TABLE "public"."event_log" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "event_log_select_admins" ON "public"."event_log" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."usuario" "u"
+  WHERE (("u"."id" = "auth"."uid"()) AND (("u"."rol")::"text" = 'admin'::"text")))));
+
+
+
+ALTER TABLE "public"."favorito" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."historial_stock" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "hs_ins_owner" ON "public"."historial_stock" FOR INSERT TO "authenticated" WITH CHECK ("public"."can_manage_producto"("producto_id"));
+
+
+
+CREATE POLICY "hs_sel_owner" ON "public"."historial_stock" FOR SELECT TO "authenticated" USING ("public"."can_manage_producto"("producto_id"));
+
+
+
+ALTER TABLE "public"."imagen_producto" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "insert_empresa_authenticated" ON "public"."empresa" FOR INSERT TO "authenticated" WITH CHECK (true);
+
+
+
+CREATE POLICY "insert_own_carrito" ON "public"."carrito" FOR INSERT TO "authenticated" WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "insert_own_favoritos" ON "public"."favorito" FOR INSERT TO "authenticated" WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "insert_own_pedidos" ON "public"."pedido" FOR INSERT TO "authenticated" WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "ip_del_owner" ON "public"."imagen_producto" FOR DELETE TO "authenticated" USING ("public"."can_manage_producto"("producto_id"));
+
+
+
+CREATE POLICY "ip_ins_owner" ON "public"."imagen_producto" FOR INSERT TO "authenticated" WITH CHECK ("public"."can_manage_producto"("producto_id"));
+
+
+
+CREATE POLICY "ip_sel_public" ON "public"."imagen_producto" FOR SELECT USING (true);
+
+
+
+CREATE POLICY "ip_upd_owner" ON "public"."imagen_producto" FOR UPDATE TO "authenticated" USING ("public"."can_manage_producto"("producto_id")) WITH CHECK ("public"."can_manage_producto"("producto_id"));
+
+
+
+ALTER TABLE "public"."log_actividad" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "log_sel_own" ON "public"."log_actividad" FOR SELECT TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+ALTER TABLE "public"."membresia" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "membresia_delete_admins" ON "public"."membresia" FOR DELETE USING ((EXISTS ( SELECT 1
+   FROM "public"."membresia" "m2"
+  WHERE (("m2"."empresa_id" = "membresia"."empresa_id") AND ("m2"."usuario_id" = "auth"."uid"()) AND ("m2"."rol" = ANY (ARRAY['owner'::"public"."rol_membresia", 'admin'::"public"."rol_membresia"]))))));
+
+
+
+CREATE POLICY "membresia_insert_admins" ON "public"."membresia" FOR INSERT TO "authenticated" WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."membresia" "m2"
+  WHERE (("m2"."empresa_id" = "membresia"."empresa_id") AND ("m2"."usuario_id" = "auth"."uid"()) AND ("m2"."rol" = ANY (ARRAY['owner'::"public"."rol_membresia", 'admin'::"public"."rol_membresia"]))))));
+
+
+
+CREATE POLICY "membresia_select_members" ON "public"."membresia" FOR SELECT USING ("public"."user_is_member_of"("empresa_id"));
+
+
+
+CREATE POLICY "membresia_update_admins" ON "public"."membresia" FOR UPDATE USING ("public"."user_is_member_of"("empresa_id")) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."membresia" "m2"
+  WHERE (("m2"."empresa_id" = "membresia"."empresa_id") AND ("m2"."usuario_id" = "auth"."uid"()) AND ("m2"."rol" = ANY (ARRAY['owner'::"public"."rol_membresia", 'admin'::"public"."rol_membresia"]))))));
+
+
+
+ALTER TABLE "public"."notificacion" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."pedido" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "pedido_del_own" ON "public"."pedido" FOR DELETE TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "pedido_ins_own" ON "public"."pedido" FOR INSERT TO "authenticated" WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "pedido_sel_own" ON "public"."pedido" FOR SELECT TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "pedido_upd_own" ON "public"."pedido" FOR UPDATE TO "authenticated" USING (("usuario_id" = "auth"."uid"())) WITH CHECK (("usuario_id" = "auth"."uid"()));
+
+
+
+ALTER TABLE "public"."producto" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "producto_del_owner" ON "public"."producto" FOR DELETE TO "authenticated" USING ("public"."is_empresa_owner"("empresa_id"));
+
+
+
+CREATE POLICY "producto_ins_owner" ON "public"."producto" FOR INSERT TO "authenticated" WITH CHECK ("public"."is_empresa_owner"("empresa_id"));
+
+
+
+CREATE POLICY "producto_public_sel" ON "public"."producto" FOR SELECT USING (true);
+
+
+
+CREATE POLICY "producto_tenant_cud" ON "public"."producto" TO "authenticated" USING ("public"."user_is_member_of"("empresa_id")) WITH CHECK ("public"."user_is_member_of"("empresa_id"));
+
+
+
+CREATE POLICY "producto_tenant_select" ON "public"."producto" FOR SELECT USING ("public"."user_is_member_of"("empresa_id"));
+
+
+
+CREATE POLICY "producto_upd_owner" ON "public"."producto" FOR UPDATE TO "authenticated" USING ("public"."is_empresa_owner"("empresa_id")) WITH CHECK ("public"."is_empresa_owner"("empresa_id"));
+
+
+
+CREATE POLICY "read_own_carrito" ON "public"."carrito" FOR SELECT TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "read_own_favoritos" ON "public"."favorito" FOR SELECT TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "read_own_pedidos" ON "public"."pedido" FOR SELECT TO "authenticated" USING (("usuario_id" = "auth"."uid"()));
+
+
+
+CREATE POLICY "select_empresa_authenticated" ON "public"."empresa" FOR SELECT TO "authenticated" USING (true);
+
+
+
+ALTER TABLE "public"."usuario" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "usuario puede actualizar productos de su empresa" ON "public"."producto" FOR UPDATE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."usuario" "u"
+  WHERE (("u"."empresa_id" = "producto"."empresa_id") AND (("u"."correo")::"text" = "auth"."email"()))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."usuario" "u"
+  WHERE (("u"."empresa_id" = "producto"."empresa_id") AND (("u"."correo")::"text" = "auth"."email"())))));
+
+
+
+CREATE POLICY "usuario puede crear productos en su empresa" ON "public"."producto" FOR INSERT TO "authenticated" WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."usuario" "u"
+  WHERE (("u"."empresa_id" = "producto"."empresa_id") AND (("u"."correo")::"text" = "auth"."email"())))));
+
+
+
+CREATE POLICY "usuario puede eliminar productos de su empresa" ON "public"."producto" FOR DELETE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."usuario" "u"
+  WHERE (("u"."empresa_id" = "producto"."empresa_id") AND (("u"."correo")::"text" = "auth"."email"())))));
+
+
+
+CREATE POLICY "usuario puede ver productos de su empresa" ON "public"."producto" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."usuario" "u"
+  WHERE (("u"."empresa_id" = "producto"."empresa_id") AND (("u"."correo")::"text" = "auth"."email"())))));
+
+
+
+CREATE POLICY "usuario_delete_own" ON "public"."usuario" FOR DELETE USING (("supabase_uid" = "auth"."uid"()));
+
+
+
+CREATE POLICY "usuario_insert_self" ON "public"."usuario" FOR INSERT WITH CHECK (("supabase_uid" = "auth"."uid"()));
+
+
+
+CREATE POLICY "usuario_puede_crear_empresa" ON "public"."empresa" FOR INSERT TO "authenticated" WITH CHECK (true);
+
+
+
+CREATE POLICY "usuario_select_own" ON "public"."usuario" FOR SELECT USING (("supabase_uid" = "auth"."uid"()));
+
+
+
+CREATE POLICY "usuario_update_own" ON "public"."usuario" FOR UPDATE USING (("supabase_uid" = "auth"."uid"())) WITH CHECK (("supabase_uid" = "auth"."uid"()));
+
+
+
+
+
+ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";
+
+
+REVOKE USAGE ON SCHEMA "public" FROM PUBLIC;
+GRANT USAGE ON SCHEMA "public" TO "authenticated";
+GRANT USAGE ON SCHEMA "public" TO "anon";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+GRANT SELECT ON TABLE "public"."carrito" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."carrito_producto" TO "authenticated";
+
+
+
+GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE "public"."categoria" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."comprobante_pago" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."direccion_usuario" TO "authenticated";
+
+
+
+GRANT SELECT,INSERT ON TABLE "public"."empresa" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."envio" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."favorito" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."historial_stock" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."imagen_producto" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."log_actividad" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."notificacion" TO "authenticated";
+
+
+
+GRANT SELECT ON TABLE "public"."pedido" TO "authenticated";
+
+
+
+GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE "public"."producto" TO "authenticated";
+
+
+
+GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE "public"."usuario" TO "authenticated";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+RESET ALL;

--- a/supabase/migrations/20251218032000_producto_estado_autodraft.sql
+++ b/supabase/migrations/20251218032000_producto_estado_autodraft.sql
@@ -1,0 +1,43 @@
+-- Agregar estado (draft/published) para flujo B1
+alter table public.producto
+add column if not exists estado text;
+
+alter table public.producto
+alter column estado set default 'draft';
+
+update public.producto
+set estado = 'draft'
+where estado is null;
+
+alter table public.producto
+alter column estado set not null;
+
+-- Constraint para evitar valores inválidos
+alter table public.producto
+drop constraint if exists producto_estado_check;
+
+alter table public.producto
+add constraint producto_estado_check
+check (estado in ('draft','published'));
+
+-- Trigger: si estaba published y se edita => vuelve a draft (B1 estricto)
+create or replace function public.producto_auto_draft_on_update()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  if old.estado = 'published' then
+    new.estado := 'draft';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_producto_auto_draft_on_update on public.producto;
+
+create trigger trg_producto_auto_draft_on_update
+before update on public.producto
+for each row
+execute function public.producto_auto_draft_on_update();


### PR DESCRIPTION
Se implementa el flujo B1 de publicación de productos a nivel base de datos.

- Se agrega la columna `estado` (draft / published) a la tabla `producto`
- Se crea un trigger que revierte automáticamente a `draft` cualquier producto `published` al ser editado
- Se ordenan y normalizan migraciones usando `remote_schema` como base
- Se limpia y estabiliza el entorno local de Supabase (CLI, Docker, storage, migraciones)
- Se asegura que la lógica de negocio quede garantizada en DB, independiente del front

Resultado:
La tienda solo puede mostrar productos publicados y cualquier edición fuerza una nueva publicación explícita.