### PR TITLE
Ruta A: endurecer contrato de producto

### DIFF
--- a/supabase/migrations/20251228015714_contrato_producto.sql
+++ b/supabase/migrations/20251228015714_contrato_producto.sql
@@ -1,0 +1,14 @@
+-- 1) empresa_id obligatorio
+alter table producto
+alter column empresa_id set not null;
+
+-- 2) estado obligatorio
+alter table producto
+alter column estado set not null;
+
+-- 3) estado con valores válidos
+alter table producto
+add constraint producto_estado_valido
+check (
+  estado in ('draft', 'published', 'paused', 'archived')
+);

--- a/supabase/migrations/20251228021537_producto_add_updated_at.sql
+++ b/supabase/migrations/20251228021537_producto_add_updated_at.sql
@@ -1,0 +1,6 @@
+alter table producto
+add column if not exists updated_at timestamptz not null default now();
+
+update producto
+set updated_at = now()
+where updated_at is null;


### PR DESCRIPTION
Se endurece el contrato de la tabla producto:
empresa_id obligatorio, validación de estado y agregado de updated_at. Migraciones reproducibles y smoke tests validados en local.