### PR TITLE
db(categoria): harden contract and dedup empresa FK

### DIFF
--- a/supabase/migrations/20260104174931_db_categoria_contract_dedup_fk_and_unique.sql
+++ b/supabase/migrations/20260104174931_db_categoria_contract_dedup_fk_and_unique.sql
@@ -1,0 +1,21 @@
+-- 0) Eliminar FK redundante (si existe)
+alter table public.categoria
+  drop constraint if exists categoria_empresa_id_fkey;
+
+-- 1) Asegurar NOT NULL
+alter table public.categoria
+  alter column empresa_id set not null;
+
+-- 2) Asegurar que exista fk_categoria_empresa con CASCADE
+alter table public.categoria
+  drop constraint if exists fk_categoria_empresa;
+
+alter table public.categoria
+  add constraint fk_categoria_empresa
+  foreign key (empresa_id)
+  references public.empresa(id)
+  on delete cascade;
+
+-- 3) Unicidad por empresa (case-insensitive)
+create unique index if not exists ux_categoria_empresa_nombre_ci
+  on public.categoria (empresa_id, lower(nombre));


### PR DESCRIPTION
- Enforce empresa_id NOT NULL
- Remove duplicate FK and keep canonical fk_categoria_empresa (ON DELETE CASCADE)
- Add unique index per empresa (case-insensitive nombre)
- Validated via db reset and smoke tests