### PR TITLE
db(producto-categoria): add bridge table with hard tenancy constraints

### DIFF
--- a/supabase/migrations/20260104180515_producto_categoria_bridge.sql
+++ b/supabase/migrations/20260104180515_producto_categoria_bridge.sql
@@ -1,0 +1,18 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ux_producto_empresa_id_id'
+  ) THEN
+    ALTER TABLE public.producto
+      ADD CONSTRAINT ux_producto_empresa_id_id UNIQUE (empresa_id, id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ux_categoria_empresa_id_id'
+  ) THEN
+    ALTER TABLE public.categoria
+      ADD CONSTRAINT ux_categoria_empresa_id_id UNIQUE (empresa_id, id);
+  END IF;
+END$$;

--- a/supabase/migrations/20260104182803_producto_categoria_table.sql
+++ b/supabase/migrations/20260104182803_producto_categoria_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS public.producto_categoria (
+  empresa_id   uuid NOT NULL,
+  producto_id  uuid NOT NULL,
+  categoria_id uuid NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (empresa_id, producto_id, categoria_id),
+  CONSTRAINT fk_pc_producto
+    FOREIGN KEY (empresa_id, producto_id)
+    REFERENCES public.producto (empresa_id, id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_pc_categoria
+    FOREIGN KEY (empresa_id, categoria_id)
+    REFERENCES public.categoria (empresa_id, id)
+    ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_pc_empresa_producto
+  ON public.producto_categoria (empresa_id, producto_id);
+
+CREATE INDEX IF NOT EXISTS idx_pc_empresa_categoria
+  ON public.producto_categoria (empresa_id, categoria_id);


### PR DESCRIPTION
- Introduce producto_categoria bridge for multi-category support
- Enforces hard tenancy via composite FKs (empresa_id + id)
- Adds unique constraints required for composite references
- Validates delete behavior (CASCADE on producto, RESTRICT on categoria)
- Leaves legacy producto.categoria_id intact for transition