### PR TITLE
db(usuario): habilitar onboarding sin empresa y reparar signup auth

### DIFF
--- a/supabase/migrations/20260105224857_fix_usuario_onboarding_empresa.sql
+++ b/supabase/migrations/20260105224857_fix_usuario_onboarding_empresa.sql
@@ -1,0 +1,29 @@
+-- 1. Permitir usuarios sin empresa durante onboarding
+alter table public.usuario
+  alter column empresa_id drop not null;
+
+-- 2. Agregar flag de onboarding
+alter table public.usuario
+  add column if not exists onboarding boolean not null default true;
+
+-- 3. Forzar empresa solo cuando termina onboarding (idempotente)
+alter table public.usuario
+  drop constraint if exists usuario_empresa_o_onboarding;
+
+alter table public.usuario
+  add constraint usuario_empresa_o_onboarding
+  check (onboarding = true or empresa_id is not null);
+
+-- 4. Limpiar FKs duplicadas (dejamos una sola)
+alter table public.usuario
+  drop constraint if exists fk_usuario_empresa;
+
+alter table public.usuario
+  drop constraint if exists usuario_empresa_id_fkey;
+
+-- 5. Crear FK única y coherente
+alter table public.usuario
+  add constraint usuario_empresa_id_fkey
+  foreign key (empresa_id)
+  references public.empresa(id)
+  on delete set null;


### PR DESCRIPTION
- empresa_id pasa a ser nullable para permitir alta de usuarios vía Supabase Auth
- se agrega flag onboarding con CHECK para exigir empresa al finalizar el registro
- se eliminan FKs duplicadas y se deja una sola FK coherente (ON DELETE SET NULL)
- se ajusta el trigger handle_new_auth_user para evitar errores 500 en signup/login