### PR TITLE
db(auth/usuario): trigger de alta + updated_at + RLS own

### DIFF
--- a/supabase/migrations/20260105230104_add_usuario_updated_at.sql
+++ b/supabase/migrations/20260105230104_add_usuario_updated_at.sql
@@ -1,0 +1,16 @@
+alter table public.usuario enable row level security;
+
+drop policy if exists usuario_select_own on public.usuario;
+create policy usuario_select_own
+on public.usuario
+for select
+to authenticated
+using (supabase_uid = auth.uid());
+
+drop policy if exists usuario_update_own on public.usuario;
+create policy usuario_update_own
+on public.usuario
+for update
+to authenticated
+using (supabase_uid = auth.uid())
+with check (supabase_uid = auth.uid());

--- a/supabase/migrations/20260105231116_usuario_add_updated_at.sql
+++ b/supabase/migrations/20260105231116_usuario_add_updated_at.sql
@@ -1,0 +1,19 @@
+alter table public.usuario
+  add column if not exists updated_at timestamptz not null default now();
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_usuario_updated_at on public.usuario;
+
+create trigger set_usuario_updated_at
+before update on public.usuario
+for each row
+execute function public.set_updated_at();

--- a/supabase/migrations/20260105232141_auth_trigger_new_user_usuario.sql
+++ b/supabase/migrations/20260105232141_auth_trigger_new_user_usuario.sql
@@ -1,0 +1,48 @@
+-- Asegurar función (la dejamos igual, pero agregamos empresa_id/onboarding/updated_at si existen)
+create or replace function public.handle_new_auth_user()
+returns trigger
+language plpgsql
+security definer
+set search_path to 'public'
+as $$
+declare
+  v_nombre text;
+begin
+  v_nombre := coalesce(
+    new.raw_user_meta_data->>'name',
+    new.raw_user_meta_data->>'full_name',
+    split_part(new.email, '@', 1),
+    'Usuario'
+  );
+
+  begin
+    insert into public.usuario (
+      id, supabase_uid, correo, nombre, rol, fecha_registro,
+      empresa_id, onboarding, updated_at
+    )
+    values (
+      new.id, new.id, new.email, v_nombre, 'cliente', now(),
+      null, true, now()
+    );
+
+  exception
+    when unique_violation then
+      update public.usuario
+         set id = new.id,
+             supabase_uid = new.id,
+             nombre = coalesce(public.usuario.nombre, v_nombre),
+             rol = coalesce(public.usuario.rol, 'cliente'),
+             updated_at = now()
+       where correo = new.email;
+  end;
+
+  return new;
+end;
+$$;
+
+-- Trigger en auth.users (idempotente)
+drop trigger if exists on_auth_user_created on auth.users;
+
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function public.handle_new_auth_user();


### PR DESCRIPTION
- agrega usuario.updated_at y trigger before update para mantener timestamps
- crea trigger on_auth_user_created en auth.users para sincronizar public.usuario
- aplica RLS en public.usuario con policies de SELECT/UPDATE own (supabase_uid = auth.uid())
- deja listo el flujo onboarding (empresa_id null, onboarding true) sin romper signup/login