### PR TITLE
feat(panel): agregar módulo de listado de pedidos para admin (B4)

### DIFF
--- a/prompts/opencode/06-panel-module-design.md
+++ b/prompts/opencode/06-panel-module-design.md
@@ -1,0 +1,101 @@
+# Panel Module Design — OAF-TC
+
+Lee el repositorio completo antes de responder.
+
+Este proyecto es un SaaS ecommerce backend-first basado en:
+
+* Next.js API routes
+* Supabase Postgres
+* RPC soberanas para operaciones críticas
+* tenancy estricta por empresa_id
+* RLS cerrada por defecto
+
+La arquitectura sigue el enfoque:
+
+contrato de dominio → DB/RPC → endpoint fino → UI
+
+No queremos mover lógica de dominio a los endpoints.
+
+---
+
+## Contexto actual del sistema
+
+El flujo de pedidos y pagos ya está implementado:
+
+pedido
+intento_pago
+checkout Mercado Pago
+webhook
+consolidación del pedido
+
+Existe ya este endpoint:
+
+GET /api/ecommerce/pedido/[id]
+
+que devuelve el detalle completo de un pedido con:
+
+* items
+* total
+* estado
+* snapshot de dirección
+* timestamps
+
+---
+
+## Objetivo del nuevo módulo
+
+Implementar el primer módulo del panel administrativo:
+
+/panel/pedidos
+
+Debe permitir:
+
+1. listar pedidos de la empresa
+2. ver estado del pedido
+3. navegar al detalle del pedido existente
+
+---
+
+## Endpoint propuesto
+
+GET /api/panel/pedidos
+
+Este endpoint debe:
+
+* autenticar usuario
+* resolver identidad desde supabase_uid
+* obtener empresa_id del usuario
+* listar pedidos de esa empresa
+* devolver los pedidos más recientes
+
+---
+
+## Requisitos arquitectónicos
+
+Mantener coherencia con el repositorio:
+
+* tenancy estricta por empresa_id
+* endpoints finos
+* evitar lógica de dominio en el endpoint
+* reutilizar helpers existentes
+* respetar patrones de auth ya usados en B3
+
+---
+
+## Tu tarea
+
+1. Analizar cómo están implementados los endpoints actuales del repo.
+2. Proponer la implementación correcta para:
+
+GET /api/panel/pedidos
+
+3. Proponer la estructura mínima de la página:
+
+/panel/pedidos
+
+4. Indicar qué código existente conviene reutilizar.
+5. Señalar posibles riesgos de tenancy o RLS.
+
+No generes código excesivo.
+
+Prioriza coherencia con la arquitectura actual del proyecto.

--- a/src/components/layout/panel/Sidebar.tsx
+++ b/src/components/layout/panel/Sidebar.tsx
@@ -26,6 +26,11 @@ const links: PanelLink[] = [
     allowedRoles: ["admin", "desarrollador"],
   },
   {
+    href: "/panel/pedidos",
+    label: "Pedidos",
+    allowedRoles: ["admin", "desarrollador"],
+  },
+  {
     href: "/panel/payments",
     label: "Pagos",
     allowedRoles: ["admin"],

--- a/src/pages/api/panel/pedidos.ts
+++ b/src/pages/api/panel/pedidos.ts
@@ -1,0 +1,135 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "@supabase/supabase-js";
+
+type PedidoEstado =
+  | "pendiente_pago"
+  | "pagado"
+  | "bloqueado"
+  | "en_preparacion"
+  | "enviado"
+  | "entregado"
+  | "cancelado";
+
+type PedidoRow = {
+  pedido_id: string;
+  estado: PedidoEstado;
+  total: number | string;
+  creado_en: string;
+  expira_en: string;
+  bloqueado_por_stock: boolean;
+};
+
+type ApiOk = {
+  pedidos: PedidoRow[];
+  meta: {
+    count: number;
+  };
+};
+
+type ApiErr = { error: string };
+
+function getAccessToken(req: NextApiRequest): string | null {
+  const auth = req.headers.authorization;
+  if (auth && typeof auth === "string") {
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m?.[1]) return m[1].trim();
+  }
+
+  const cookie = req.headers.cookie;
+  if (cookie && typeof cookie === "string") {
+    const m = cookie.match(/(?:^|;\s*)sb-access-token=([^;]+)/);
+    if (m?.[1]) return decodeURIComponent(m[1]);
+  }
+
+  return null;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiOk | ApiErr>
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!SUPABASE_URL || !ANON_KEY || !SERVICE_ROLE) {
+    return res.status(500).json({
+      error:
+        "Server misconfigured: falta NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY o SUPABASE_SERVICE_ROLE_KEY",
+    });
+  }
+
+  const access_token = getAccessToken(req);
+  if (!access_token) {
+    return res.status(401).json({ error: "Falta access token" });
+  }
+
+  const supabaseAuth = createClient(SUPABASE_URL, ANON_KEY, {
+    global: { headers: { Authorization: `Bearer ${access_token}` } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: userData, error: userErr } = await supabaseAuth.auth.getUser();
+
+  if (userErr || !userData?.user) {
+    return res.status(401).json({ error: "Token inválido o expirado" });
+  }
+
+  const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+  const { data: perfil, error: perfilErr } = await supabaseAdmin
+    .from("usuario")
+    .select("empresa_id")
+    .eq("supabase_uid", userData.user.id)
+    .maybeSingle();
+
+  if (perfilErr) {
+    return res
+      .status(500)
+      .json({ error: `Error validando usuario: ${perfilErr.message}` });
+  }
+
+  if (!perfil?.empresa_id) {
+    return res.status(403).json({ error: "Usuario sin empresa asociada" });
+  }
+
+  try {
+    const { data: pedidosData, error: pedidosError } = await supabaseAdmin
+      .from("pedido")
+      .select("id, estado, total, creado_en, expira_en, bloqueado_por_stock")
+      .eq("empresa_id", perfil.empresa_id)
+      .order("creado_en", { ascending: false })
+      .limit(50);
+
+    if (pedidosError) {
+      return res.status(500).json({ error: pedidosError.message });
+    }
+
+    const pedidos: PedidoRow[] = (pedidosData ?? []).map((pedido) => ({
+      pedido_id: pedido.id,
+      estado: pedido.estado as PedidoEstado,
+      total: Number(pedido.total),
+      creado_en: pedido.creado_en,
+      expira_en: pedido.expira_en,
+      bloqueado_por_stock: Boolean(pedido.bloqueado_por_stock),
+    }));
+
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("X-Panel-Only", "1");
+    res.setHeader("X-Auth-Mode", "bearer_or_cookie");
+
+    return res.status(200).json({
+      pedidos,
+      meta: {
+        count: pedidos.length,
+      },
+    });
+  } catch (e: any) {
+    return res.status(500).json({ error: e?.message ?? "unknown error" });
+  }
+}

--- a/src/pages/panel/pedidos/index.tsx
+++ b/src/pages/panel/pedidos/index.tsx
@@ -1,0 +1,212 @@
+import React, { useCallback, useEffect, useState } from "react";
+import AdminLayout from "../../../components/layout/AdminLayout";
+import { supabase } from "../../../lib/supabaseClient";
+
+type PedidoEstado =
+  | "pendiente_pago"
+  | "pagado"
+  | "bloqueado"
+  | "en_preparacion"
+  | "enviado"
+  | "entregado"
+  | "cancelado";
+
+type PedidoPanelDTO = {
+  pedido_id: string;
+  estado: PedidoEstado;
+  total: number;
+  creado_en: string;
+  expira_en: string;
+  bloqueado_por_stock: boolean;
+};
+
+type ApiOk = {
+  pedidos: PedidoPanelDTO[];
+  meta: {
+    count: number;
+  };
+};
+
+const estadoLabel: Record<PedidoEstado, string> = {
+  pendiente_pago: "Pendiente pago",
+  pagado: "Pagado",
+  bloqueado: "Bloqueado",
+  en_preparacion: "En preparación",
+  enviado: "Enviado",
+  entregado: "Entregado",
+  cancelado: "Cancelado",
+};
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString("es-UY", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const PanelPedidosPage: React.FC = () => {
+  const [pedidos, setPedidos] = useState<PedidoPanelDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const fetchPedidos = useCallback(async () => {
+    try {
+      setLoading(true);
+      setErrorMsg(null);
+
+      const {
+        data: { session },
+        error: sessErr,
+      } = await supabase.auth.getSession();
+
+      if (sessErr) console.error("[pedidos] getSession error:", sessErr);
+
+      const accessToken = session?.access_token;
+      if (!accessToken) {
+        setPedidos([]);
+        setErrorMsg("Sesión no válida. Volvé a iniciar sesión.");
+        return;
+      }
+
+      const r = await fetch("/api/panel/pedidos", {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      if (!r.ok) {
+        const txt = await r.text().catch(() => "");
+        console.error("[pedidos] endpoint error:", r.status, txt);
+        setPedidos([]);
+        setErrorMsg("No se pudieron cargar los pedidos.");
+        return;
+      }
+
+      const data = (await r.json()) as ApiOk;
+      setPedidos(data.pedidos ?? []);
+    } catch (err) {
+      console.error(err);
+      setPedidos([]);
+      setErrorMsg("Ocurrió un error al cargar los pedidos.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPedidos();
+  }, [fetchPedidos]);
+
+  return (
+    <AdminLayout>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Pedidos</h1>
+          <p className="text-sm text-slate-300">
+            Revisá los pedidos más recientes de tu empresa.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={fetchPedidos}
+          disabled={loading}
+          className="rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-white hover:bg-white/15 disabled:opacity-60"
+        >
+          {loading ? "Cargando…" : "Refrescar"}
+        </button>
+      </div>
+
+      {loading && <p className="text-sm text-slate-300">Cargando pedidos…</p>}
+
+      {errorMsg && !loading && (
+        <p className="mb-3 text-sm text-rose-400">{errorMsg}</p>
+      )}
+
+      {!loading && !errorMsg && pedidos.length === 0 && (
+        <p className="text-sm text-slate-400">Todavía no hay pedidos.</p>
+      )}
+
+      {!loading && pedidos.length > 0 && (
+        <div className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-950/40">
+          <table className="min-w-full text-sm">
+            <thead className="bg-slate-900/60">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium text-slate-300">
+                  Pedido
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-slate-300">
+                  Estado
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-slate-300">
+                  Total
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-slate-300">
+                  Creado
+                </th>
+                <th className="px-4 py-2 text-left font-medium text-slate-300">
+                  Expira
+                </th>
+                <th className="px-4 py-2 text-right font-medium text-slate-300">
+                  Acciones
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {pedidos.map((pedido) => (
+                <tr key={pedido.pedido_id} className="border-t border-slate-800">
+                  <td className="px-4 py-2 font-mono text-xs text-slate-200">
+                    {pedido.pedido_id}
+                  </td>
+
+                  <td className="px-4 py-2">
+                    <span
+                      className={
+                        pedido.bloqueado_por_stock
+                          ? "text-amber-300"
+                          : "text-slate-200"
+                      }
+                    >
+                      {estadoLabel[pedido.estado] ?? pedido.estado}
+                    </span>
+                  </td>
+
+                  <td className="px-4 py-2 text-slate-200">
+                    {Number(pedido.total).toLocaleString("es-UY", {
+                      style: "currency",
+                      currency: "UYU",
+                    })}
+                  </td>
+
+                  <td className="px-4 py-2 text-slate-300">
+                    {formatDate(pedido.creado_en)}
+                  </td>
+
+                  <td className="px-4 py-2 text-slate-300">
+                    {formatDate(pedido.expira_en)}
+                  </td>
+
+                  <td className="px-4 py-2 text-right">
+                    <span className="text-xs font-medium text-slate-500">
+                      Detalle próximamente
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </AdminLayout>
+  );
+};
+
+export default PanelPedidosPage;


### PR DESCRIPTION
Se implementa el primer módulo de gestión de pedidos en el panel administrativo como parte del bloque B4.

Cambios incluidos:

- Nuevo endpoint GET /api/panel/pedidos
  - autenticación mediante bearer token o cookie
  - resolución de usuario vía supabase_uid
  - derivación de empresa_id desde public.usuario
  - filtrado estricto por empresa_id
  - listado de pedidos ordenado por creado_en DESC (limit 50)

- Nueva página /panel/pedidos
  - fetch autenticado usando supabase.auth.getSession()
  - tabla con pedidos recientes
  - visualización de estado, total, fechas y expiración
  - botón de refresco manual

- Navegación del panel actualizada
  - se agrega sección "Pedidos" en Sidebar

- Prompt operativo agregado
  - prompts/opencode/06-panel-module-design.md
  - usado para generar el módulo mediante OpenCode siguiendo la arquitectura del proyecto.

Notas:

- Tenancy estricta por empresa_id derivada desde supabase_uid.
- No se modifican endpoints ecommerce existentes.
- Este bloque da visibilidad operativa a los pedidos creados por el sistema (B3).