### PR TITLE
feat(panel): implementar detalle de pedido admin en panel (B4.2)

### DIFF
--- a/src/pages/api/panel/pedidos/[id].ts
+++ b/src/pages/api/panel/pedidos/[id].ts
@@ -1,0 +1,252 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "@supabase/supabase-js";
+
+type PedidoEstado =
+  | "pendiente_pago"
+  | "pagado"
+  | "bloqueado"
+  | "en_preparacion"
+  | "enviado"
+  | "entregado"
+  | "cancelado";
+
+type IntentoPagoEstado =
+  | "iniciado"
+  | "aprobado"
+  | "rechazado"
+  | "cancelado"
+  | "expirado";
+
+type PedidoItemResponse = {
+  producto_id: string | null;
+  variante_id: string | null;
+  nombre_producto: string;
+  talle: string | null;
+  precio_unitario: number;
+  cantidad: number;
+  subtotal: number;
+};
+
+type IntentoPagoResponse = {
+  id: string;
+  estado: IntentoPagoEstado;
+  canal_pago: string;
+  external_id: string | null;
+  preference_id?: string | null;
+  creado_en: string;
+  actualizado_en: string;
+};
+
+type ApiOk = {
+  pedido: {
+    pedido_id: string;
+    estado: PedidoEstado;
+    total: number;
+    expira_en: string;
+    bloqueado_por_stock: boolean;
+    direccion_envio_snapshot: unknown;
+    creado_en: string;
+    actualizado_en: string;
+    items: PedidoItemResponse[];
+    intento_pago: IntentoPagoResponse | null;
+  };
+};
+
+type ApiErr = { error: string };
+
+function getAccessToken(req: NextApiRequest): string | null {
+  const auth = req.headers.authorization;
+  if (auth && typeof auth === "string") {
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m?.[1]) return m[1].trim();
+  }
+
+  const cookie = req.headers.cookie;
+  if (cookie && typeof cookie === "string") {
+    const m = cookie.match(/(?:^|;\s*)sb-access-token=([^;]+)/);
+    if (m?.[1]) return decodeURIComponent(m[1]);
+  }
+
+  return null;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiOk | ApiErr>
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const rawId = req.query.id;
+  const pedidoId = Array.isArray(rawId) ? rawId[0] : rawId;
+  const pedidoIdTrimmed = typeof pedidoId === "string" ? pedidoId.trim() : "";
+
+  if (!pedidoIdTrimmed) {
+    return res.status(404).json({ error: "pedido_no_encontrado" });
+  }
+
+  const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!SUPABASE_URL || !ANON_KEY || !SERVICE_ROLE) {
+    return res.status(500).json({ error: "server_misconfigured" });
+  }
+
+  try {
+    const accessToken = getAccessToken(req);
+
+    if (!accessToken) {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+
+    const supabaseAuth = createClient(SUPABASE_URL, ANON_KEY, {
+      global: {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+
+    const { data: userData, error: userErr } = await supabaseAuth.auth.getUser();
+
+    if (userErr || !userData?.user) {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+
+    const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+    const { data: perfil, error: perfilErr } = await supabaseAdmin
+      .from("usuario")
+      .select("empresa_id, rol")
+      .eq("supabase_uid", userData.user.id)
+      .maybeSingle();
+
+    if (perfilErr) {
+      console.error("[GET /api/panel/pedidos/:id] perfilErr", perfilErr);
+      return res.status(500).json({ error: "internal_error" });
+    }
+
+    if (!perfil?.empresa_id) {
+      return res.status(403).json({ error: "forbidden" });
+    }
+
+    if (!perfil.rol || !["admin", "desarrollador"].includes(perfil.rol)) {
+      return res.status(403).json({ error: "forbidden" });
+    }
+
+    const { data: pedido, error: pedidoErr } = await supabaseAdmin
+      .from("pedido")
+      .select(
+        `
+          id,
+          empresa_id,
+          estado,
+          total,
+          expira_en,
+          bloqueado_por_stock,
+          direccion_envio_snapshot,
+          creado_en,
+          actualizado_en
+        `
+      )
+      .eq("id", pedidoIdTrimmed)
+      .eq("empresa_id", perfil.empresa_id)
+      .maybeSingle();
+
+    if (pedidoErr) {
+      console.error("[GET /api/panel/pedidos/:id] pedidoErr", pedidoErr);
+      return res.status(500).json({ error: "internal_error" });
+    }
+
+    if (!pedido) {
+      return res.status(404).json({ error: "pedido_no_encontrado" });
+    }
+
+    const { data: items, error: itemsErr } = await supabaseAdmin
+      .from("pedido_item")
+      .select(
+        `
+          producto_id,
+          variante_id,
+          nombre_producto,
+          talle,
+          precio_unitario,
+          cantidad,
+          subtotal
+        `
+      )
+      .eq("pedido_id", pedido.id)
+      .eq("empresa_id", pedido.empresa_id);
+
+    if (itemsErr) {
+      console.error("[GET /api/panel/pedidos/:id] itemsErr", itemsErr);
+      return res.status(500).json({ error: "internal_error" });
+    }
+
+    const { data: intentoPago, error: intentoPagoErr } = await supabaseAdmin
+      .from("intento_pago")
+      .select(
+        "id, estado, canal_pago, external_id, preference_id, creado_en, actualizado_en"
+      )
+      .eq("pedido_id", pedido.id)
+      .eq("empresa_id", pedido.empresa_id)
+      .order("creado_en", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (intentoPagoErr) {
+      console.error(
+        "[GET /api/panel/pedidos/:id] intentoPagoErr",
+        intentoPagoErr
+      );
+      return res.status(500).json({ error: "internal_error" });
+    }
+
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("X-Panel-Only", "1");
+    res.setHeader("X-Auth-Mode", "bearer_or_cookie");
+
+    return res.status(200).json({
+      pedido: {
+        pedido_id: pedido.id,
+        estado: pedido.estado as PedidoEstado,
+        total: Number(pedido.total),
+        expira_en: pedido.expira_en,
+        bloqueado_por_stock: Boolean(pedido.bloqueado_por_stock),
+        direccion_envio_snapshot: pedido.direccion_envio_snapshot,
+        creado_en: pedido.creado_en,
+        actualizado_en: pedido.actualizado_en,
+        items: (items ?? []).map((item) => ({
+          producto_id: item.producto_id,
+          variante_id: item.variante_id,
+          nombre_producto: item.nombre_producto,
+          talle: item.talle,
+          precio_unitario: Number(item.precio_unitario),
+          cantidad: Number(item.cantidad),
+          subtotal: Number(item.subtotal),
+        })),
+        intento_pago: intentoPago
+          ? {
+              id: intentoPago.id,
+              estado: intentoPago.estado as IntentoPagoEstado,
+              canal_pago: intentoPago.canal_pago,
+              external_id: intentoPago.external_id,
+              preference_id: intentoPago.preference_id ?? null,
+              creado_en: intentoPago.creado_en,
+              actualizado_en: intentoPago.actualizado_en,
+            }
+          : null,
+      },
+    });
+  } catch (error) {
+    console.error("[GET /api/panel/pedidos/:id] unexpected", error);
+    return res.status(500).json({ error: "internal_error" });
+  }
+}

--- a/src/pages/panel/pedidos/[id].tsx
+++ b/src/pages/panel/pedidos/[id].tsx
@@ -1,0 +1,358 @@
+import React, { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import AdminLayout from "../../../components/layout/AdminLayout";
+import { supabase } from "../../../lib/supabaseClient";
+
+type PedidoEstado =
+  | "pendiente_pago"
+  | "pagado"
+  | "bloqueado"
+  | "en_preparacion"
+  | "enviado"
+  | "entregado"
+  | "cancelado";
+
+type IntentoPagoEstado =
+  | "iniciado"
+  | "aprobado"
+  | "rechazado"
+  | "cancelado"
+  | "expirado";
+
+type PedidoItem = {
+  producto_id: string | null;
+  variante_id: string | null;
+  nombre_producto: string;
+  talle: string | null;
+  precio_unitario: number;
+  cantidad: number;
+  subtotal: number;
+};
+
+type IntentoPago = {
+  id: string;
+  estado: IntentoPagoEstado;
+  canal_pago: string;
+  external_id: string | null;
+  preference_id?: string | null;
+  creado_en: string;
+  actualizado_en: string;
+};
+
+type PedidoDetail = {
+  pedido_id: string;
+  estado: PedidoEstado;
+  total: number;
+  expira_en: string;
+  bloqueado_por_stock: boolean;
+  direccion_envio_snapshot: unknown;
+  creado_en: string;
+  actualizado_en: string;
+  items: PedidoItem[];
+  intento_pago: IntentoPago | null;
+};
+
+type ApiOk = {
+  pedido: PedidoDetail;
+};
+
+const estadoLabel: Record<PedidoEstado, string> = {
+  pendiente_pago: "Pendiente pago",
+  pagado: "Pagado",
+  bloqueado: "Bloqueado",
+  en_preparacion: "En preparación",
+  enviado: "Enviado",
+  entregado: "Entregado",
+  cancelado: "Cancelado",
+};
+
+const intentoEstadoLabel: Record<IntentoPagoEstado, string> = {
+  iniciado: "Iniciado",
+  aprobado: "Aprobado",
+  rechazado: "Rechazado",
+  cancelado: "Cancelado",
+  expirado: "Expirado",
+};
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString("es-UY", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function renderSnapshot(snapshot: unknown): string {
+  if (!snapshot || typeof snapshot !== "object") {
+    return "Sin snapshot disponible";
+  }
+
+  const data = snapshot as Record<string, unknown>;
+  const parts = [
+    data.direccion,
+    data.ciudad,
+    data.pais,
+    data.codigo_postal,
+  ].filter((value) => typeof value === "string" && value.trim().length > 0);
+
+  return parts.length > 0 ? parts.join(", ") : "Sin snapshot disponible";
+}
+
+const PanelPedidoDetailPage: React.FC = () => {
+  const router = useRouter();
+  const pedidoId =
+    typeof router.query.id === "string" ? router.query.id.trim() : "";
+
+  const [pedido, setPedido] = useState<PedidoDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const fetchPedido = useCallback(async () => {
+    if (!pedidoId) return;
+
+    try {
+      setLoading(true);
+      setErrorMsg(null);
+
+      const {
+        data: { session },
+        error: sessErr,
+      } = await supabase.auth.getSession();
+
+      if (sessErr) console.error("[panel-pedido-detail] getSession error:", sessErr);
+
+      const accessToken = session?.access_token;
+      if (!accessToken) {
+        setPedido(null);
+        setErrorMsg("Sesión no válida. Volvé a iniciar sesión.");
+        return;
+      }
+
+      const r = await fetch(`/api/panel/pedidos/${pedidoId}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      if (!r.ok) {
+        const txt = await r.text().catch(() => "");
+        console.error("[panel-pedido-detail] endpoint error:", r.status, txt);
+        setPedido(null);
+        setErrorMsg(
+          r.status === 404
+            ? "Pedido no encontrado."
+            : "No se pudo cargar el detalle del pedido."
+        );
+        return;
+      }
+
+      const data = (await r.json()) as ApiOk;
+      setPedido(data.pedido);
+    } catch (err) {
+      console.error(err);
+      setPedido(null);
+      setErrorMsg("Ocurrió un error al cargar el detalle del pedido.");
+    } finally {
+      setLoading(false);
+    }
+  }, [pedidoId]);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (!pedidoId) {
+      setLoading(false);
+      setErrorMsg("Pedido inválido.");
+      return;
+    }
+
+    fetchPedido();
+  }, [fetchPedido, pedidoId, router.isReady]);
+
+  return (
+    <AdminLayout>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div>
+          <Link
+            href="/panel/pedidos"
+            className="text-sm font-medium text-emerald-400 hover:underline"
+          >
+            Volver a pedidos
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold">Detalle del pedido</h1>
+          {pedidoId && (
+            <p className="mt-1 font-mono text-xs text-slate-400">{pedidoId}</p>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={fetchPedido}
+          disabled={loading || !pedidoId}
+          className="rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-white hover:bg-white/15 disabled:opacity-60"
+        >
+          {loading ? "Cargando…" : "Refrescar"}
+        </button>
+      </div>
+
+      {loading && <p className="text-sm text-slate-300">Cargando detalle…</p>}
+
+      {errorMsg && !loading && (
+        <p className="mb-4 text-sm text-rose-400">{errorMsg}</p>
+      )}
+
+      {!loading && pedido && (
+        <div className="space-y-6">
+          <section className="grid grid-cols-1 gap-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4 md:grid-cols-2 xl:grid-cols-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Estado</p>
+              <p className="mt-1 text-sm text-slate-100">
+                {estadoLabel[pedido.estado] ?? pedido.estado}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Total</p>
+              <p className="mt-1 text-sm text-slate-100">
+                {pedido.total.toLocaleString("es-UY", {
+                  style: "currency",
+                  currency: "UYU",
+                })}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Bloqueado por stock</p>
+              <p className="mt-1 text-sm text-slate-100">
+                {pedido.bloqueado_por_stock ? "Sí" : "No"}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Creado</p>
+              <p className="mt-1 text-sm text-slate-100">{formatDate(pedido.creado_en)}</p>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Expira</p>
+              <p className="mt-1 text-sm text-slate-100">{formatDate(pedido.expira_en)}</p>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Actualizado</p>
+              <p className="mt-1 text-sm text-slate-100">{formatDate(pedido.actualizado_en)}</p>
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-slate-800 bg-slate-950/40 p-4">
+            <h2 className="text-lg font-medium text-slate-100">Dirección snapshot</h2>
+            <p className="mt-3 text-sm text-slate-300">
+              {renderSnapshot(pedido.direccion_envio_snapshot)}
+            </p>
+          </section>
+
+          <section className="rounded-xl border border-slate-800 bg-slate-950/40 p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h2 className="text-lg font-medium text-slate-100">Intento de pago</h2>
+            </div>
+
+            {!pedido.intento_pago ? (
+              <p className="text-sm text-slate-400">No hay intento de pago asociado.</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">ID</p>
+                  <p className="mt-1 break-all font-mono text-xs text-slate-100">
+                    {pedido.intento_pago.id}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Estado</p>
+                  <p className="mt-1 text-sm text-slate-100">
+                    {intentoEstadoLabel[pedido.intento_pago.estado] ?? pedido.intento_pago.estado}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Canal</p>
+                  <p className="mt-1 text-sm text-slate-100">{pedido.intento_pago.canal_pago}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Preference ID</p>
+                  <p className="mt-1 break-all font-mono text-xs text-slate-100">
+                    {pedido.intento_pago.preference_id ?? "-"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">External ID</p>
+                  <p className="mt-1 break-all font-mono text-xs text-slate-100">
+                    {pedido.intento_pago.external_id ?? "-"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Actualizado</p>
+                  <p className="mt-1 text-sm text-slate-100">
+                    {formatDate(pedido.intento_pago.actualizado_en)}
+                  </p>
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-xl border border-slate-800 bg-slate-950/40 p-4">
+            <h2 className="mb-3 text-lg font-medium text-slate-100">Items</h2>
+
+            {pedido.items.length === 0 ? (
+              <p className="text-sm text-slate-400">Este pedido no tiene items.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead className="bg-slate-900/60">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium text-slate-300">Producto</th>
+                      <th className="px-4 py-2 text-left font-medium text-slate-300">Talle</th>
+                      <th className="px-4 py-2 text-left font-medium text-slate-300">Cantidad</th>
+                      <th className="px-4 py-2 text-left font-medium text-slate-300">Precio</th>
+                      <th className="px-4 py-2 text-left font-medium text-slate-300">Subtotal</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pedido.items.map((item, index) => (
+                      <tr
+                        key={`${item.producto_id ?? "item"}-${index}`}
+                        className="border-t border-slate-800"
+                      >
+                        <td className="px-4 py-2 text-slate-200">{item.nombre_producto}</td>
+                        <td className="px-4 py-2 text-slate-300">{item.talle ?? "-"}</td>
+                        <td className="px-4 py-2 text-slate-300">{item.cantidad}</td>
+                        <td className="px-4 py-2 text-slate-300">
+                          {item.precio_unitario.toLocaleString("es-UY", {
+                            style: "currency",
+                            currency: "UYU",
+                          })}
+                        </td>
+                        <td className="px-4 py-2 text-slate-100">
+                          {item.subtotal.toLocaleString("es-UY", {
+                            style: "currency",
+                            currency: "UYU",
+                          })}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+    </AdminLayout>
+  );
+};
+
+export default PanelPedidoDetailPage;

--- a/src/pages/panel/pedidos/index.tsx
+++ b/src/pages/panel/pedidos/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import AdminLayout from "../../../components/layout/AdminLayout";
 import { supabase } from "../../../lib/supabaseClient";
 
@@ -195,9 +196,12 @@ const PanelPedidosPage: React.FC = () => {
                   </td>
 
                   <td className="px-4 py-2 text-right">
-                    <span className="text-xs font-medium text-slate-500">
-                      Detalle próximamente
-                    </span>
+                    <Link
+                      href={`/panel/pedidos/${pedido.pedido_id}`}
+                      className="text-xs font-medium text-emerald-400 hover:underline"
+                    >
+                      Ver detalle
+                    </Link>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Resumen
Implementa B4.2 para permitir ver el detalle de un pedido desde el panel admin.

## Incluye
- nuevo endpoint `GET /api/panel/pedidos/[id]`
- nueva página `/panel/pedidos/[id]`
- navegación real desde `/panel/pedidos`

## Criterios
- boundary por `empresa_id`
- autorización por rol (`admin`, `desarrollador`)
- no reutiliza endpoint ecommerce del cliente
- endpoint fino, sin lógica de dominio en API

## Datos mostrados
- pedido
- items
- direccion_envio_snapshot
- estado
- total
- expira_en
- bloqueado_por_stock
- último intento de pago asociado

## Validación
- eslint dirigido sobre archivos de B4.2 ✅
- build OK con warnings no bloqueantes ✅