### PR TITLE
fix(security): allow local Supabase in development CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,38 @@
 import type { NextConfig } from "next";
 
+const supabaseOrigin = (() => {
+  if (process.env.NODE_ENV !== "development") {
+    return null;
+  }
+
+  const rawUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!rawUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(rawUrl);
+
+    if (
+      url.protocol !== "http:" ||
+      (url.hostname !== "127.0.0.1" && url.hostname !== "localhost")
+    ) {
+      return null;
+    }
+
+    return url.origin;
+  } catch {
+    return null;
+  }
+})();
+
+const connectSrc = ["'self'", "https:", "wss:"];
+
+if (supabaseOrigin) {
+  connectSrc.push(supabaseOrigin);
+}
+
 const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -10,9 +43,9 @@ const contentSecurityPolicy = [
   "font-src 'self' https: data:",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
   "style-src 'self' 'unsafe-inline' https:",
-  "connect-src 'self' https: wss:",
+  `connect-src ${connectSrc.join(" ")}`,
   "frame-src 'self' https://www.mercadopago.com https://*.mercadopago.com",
-  "upgrade-insecure-requests",
+  ...(process.env.NODE_ENV === "development" ? [] : ["upgrade-insecure-requests"]),
 ].join("; ");
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
Part of #31

Summary
- Allows local Supabase traffic in the development CSP.
- Keeps the production policy unchanged while unblocking local development.

Focused changes
- Adds a development-only CSP allowance for local Supabase.
- Leaves the production CSP boundary intact.

Verification evidence
- Manual review confirms the allowance is scoped to development.
- No production CSP widening is introduced.

Issue
- Part of #31

Dependencies / base
- Base: fix/p0-api-authorization
- Head: fix/p0-security-hardening
- Parent: #36 fix/p0-api-authorization (https://github.com/crisvaliente/ecommerce/pull/36)
- Child: none

Rollback
- Remove the development-only Supabase CSP allowance if this slice needs to be reverted.

Chain
```text
master
`-- #32 chore/p0-stabilization-tracker (https://github.com/crisvaliente/ecommerce/pull/32)
    `-- #33 chore/p0-eslint-next16 (https://github.com/crisvaliente/ecommerce/pull/33)
        `-- #34 refactor/p0-storefront-core (https://github.com/crisvaliente/ecommerce/pull/34)
            `-- #35 refactor/p0-storefront-config (https://github.com/crisvaliente/ecommerce/pull/35)
                `-- #36 fix/p0-api-authorization (https://github.com/crisvaliente/ecommerce/pull/36)
                    `-- [CURRENT] #37 fix/p0-security-hardening (https://github.com/crisvaliente/ecommerce/pull/37)
```